### PR TITLE
various updates to OpenRefine GREL script

### DIFF
--- a/OpenRefine/post_processing.json
+++ b/OpenRefine/post_processing.json
@@ -32,6 +32,19 @@
       "mode": "row-based"
     },
     "baseColumnName": "taxonfullname",
+    "expression": "grel:if(value.contains(\"x \"), \"True\", \"False\")",
+    "onError": "set-to-blank",
+    "newColumnName": "ishybrid",
+    "columnInsertIndex": 4,
+    "description": "Create column ishybrid at index 4 based on column taxonfullname using expression grel:if(value.contains(\"x \"), \"True\", \"False\")"
+  },
+  {
+    "op": "core/column-addition",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "baseColumnName": "taxonfullname",
     "expression": "grel:if(value.contains(' sp. '), 'sp.', '')",
     "onError": "set-to-blank",
     "newColumnName": "qualifier",
@@ -84,12 +97,12 @@
       "mode": "row-based"
     },
     "baseColumnName": "taxonfullname",
-    "expression": "grel:if(cells['rankid'].value >= 220, value.split(' ')[1], '')",
+    "expression": "grel:if(cells['rankid'].value >= 220, if(cells['ishybrid'].value == 'True', forEach(value.split(' '), w, if(startsWith(w, toLowercase(w)), w, '')).join(' ').trim(), value.split(' ')[1]), '')",
     "onError": "set-to-blank",
     "newColumnName": "species",
     "columnInsertIndex": 5,
-    "description": "Create column species at index 5 based on column taxonfullname using expression grel:if(cells['rankid'].value >= 220, value.split(' ')[1], '')"
-  },
+    "description": "Create column species based on taxonfullname and include lowercase words if ishybrid is True."
+  },  
   {
     "op": "core/column-addition",
     "engineConfig": {
@@ -948,32 +961,6 @@
       "facets": [],
       "mode": "row-based"
     },
-    "baseColumnName": "remarks",
-    "expression": "grel:if(value != null,cells.catalogeddate.value,null)",
-    "onError": "set-to-blank",
-    "newColumnName": "remark date",
-    "columnInsertIndex": 57,
-    "description": "Create column remark date at index 57 based on column remarks using expression grel:if(value != null,cells.catalogeddate.value,null)"
-  },
-  {
-    "op": "core/column-addition",
-    "engineConfig": {
-      "facets": [],
-      "mode": "row-based"
-    },
-    "baseColumnName": "remarks",
-    "expression": "grel:if(value != null,\"DaSSCo digitisation\",null)",
-    "onError": "set-to-blank",
-    "newColumnName": "remark source",
-    "columnInsertIndex": 57,
-    "description": "Create column remark source at index 57 based on column remarks using expression grel:if(value != null,\"DaSSCo digitisation\",null)"
-  },
-  {
-    "op": "core/column-addition",
-    "engineConfig": {
-      "facets": [],
-      "mode": "row-based"
-    },
     "baseColumnName": "id",
     "expression": "grel:\"True\"",
     "onError": "set-to-blank",
@@ -1131,11 +1118,63 @@
       "mode": "row-based"
     },
     "columnName": "remarks",
-    "expression": "grel:if(cells[\"remarks\"].value.contains(\"loco ignoto vel cult.\"), \n    cells[\"remarks\"].value.replace(/\\s*;?\\s*loco ignoto vel cult\\.\\s*;?\\s*/, \"\"), \n    cells[\"remarks\"].value)",
+    "expression": "grel:value.replace('loco ignoto vel cult.','').trim()",
     "onError": "keep-original",
     "repeat": false,
     "repeatCount": 10,
-    "description": "Text transform on cells in column remarks using expression grel:if(cells[\"remarks\"].value.contains(\"loco ignoto vel cult.\"), \n    cells[\"remarks\"].value.replace(/\\s*;?\\s*loco ignoto vel cult\\.\\s*;?\\s*/, \"\"), \n    cells[\"remarks\"].value)"
+    "description": "Remove 'loco ignoto vel cult.' from remarks"
+  },
+  {
+    "op": "core/column-addition",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "baseColumnName": "remarks",
+    "expression": "grel:if(cells[\"remarks\"].value.contains(\"sensu lato\"), \"sensu lato\", cells[\"addendum\"].value)",
+    "onError": "set-to-blank",
+    "newColumnName": "addendum",
+    "columnInsertIndex": 27,
+    "description": "Create column addendum at index 27 based on column remarks using expression grel:if(cells[\"remarks\"].value.contains(\"sensu lato\"), \"sensu lato\", cells[\"addendum\"].value)"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "remarks",
+    "expression": "grel:value.replace('sensu lato','').replace('sensu stricto','').trim()",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Remove 'sensu lato' and 'sensu stricto' from remarks"
+  },
+  {
+    "op": "core/column-addition",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "baseColumnName": "remarks",
+    "expression": "grel:if(isNonBlank(value),cells.catalogeddate.value,null)",
+    "onError": "set-to-blank",
+    "newColumnName": "remark date",
+    "columnInsertIndex": 57,
+    "description": "Create column remark date at index 57 based on column remarks using expression grel:if(value != null,cells.catalogeddate.value,null)"
+  },
+  {
+    "op": "core/column-addition",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "baseColumnName": "remarks",
+    "expression": "grel:if(isNonBlank(value),\"DaSSCo digitisation\",null)",
+    "onError": "set-to-blank",
+    "newColumnName": "remark source",
+    "columnInsertIndex": 57,
+    "description": "Create column remark source at index 57 based on column remarks using expression grel:if(value != null,\"DaSSCo digitisation\",null)"
   },
   {
     "op": "core/column-reorder",
@@ -1184,6 +1223,8 @@
       "forma_author",
       "newformaflag",
       "qualifier",
+      "addendum",
+      "ishybrid",
       "typestatusname",
       "storedunder",
       "localityname",


### PR DESCRIPTION
- sensu lato / sensu stricto taken from notes and added to addendum
- hybrids get ishybrid=True
- moved some things around to avoid blank remarks fields getting remark date and remark source
- changed the remark date and remark source field to add values if remarks isNonBlank instead of null to fix issue of blank strings in remarks triggering date and source